### PR TITLE
Floating Point Literal Format

### DIFF
--- a/mobile/ios/coding-standards/style-guide.md
+++ b/mobile/ios/coding-standards/style-guide.md
@@ -165,6 +165,17 @@ As Apple mention in their Apple Pay documentation, floats and doubles are not to
 
 > Although they may appear to be more convenient, IEEE floating point data types such as float and Double are not suitable for financial calculations. These data types use a base-2 representation of numbers, which means that some decimal numbers can’t be represented exactly—for example, 0.42 must be approximated as 0.41999 repeating. Such approximations can cause financial calculations to return incorrect results. [developer.apple.com/library/ios/ApplePay_Guide/CreateRequest.html](https://developer.apple.com/library/ios/ApplePay_Guide/CreateRequest.html#//apple_ref/doc/uid/TP40014764-CH3-SW2)
 
+### Floating Point Format
+When writing float or double literals, prefer the Swift compatible version with digits either side of the point. For example:
+
+```objectivec
+10.0 // double (not 10.)
+```
+
+```objectivec
+10.0f // float (not 10.f)
+```
+
 ### Avoiding Half Pixel Calculations
 Round all calculations that have to do with UI layout. There are some exceptions to this (such as rendering a 2 pixel line, either side of a half pixel) but as a general rule, rounded CGFloats avoid fuzziness.
 


### PR DESCRIPTION
As we move to Swift, we will adopt the Swift floating point literal format.
