### PR TITLE
fixes broken link to eslint

### DIFF
--- a/javascript/coding-standards/README.md
+++ b/javascript/coding-standards/README.md
@@ -2,7 +2,7 @@
 
 We previously followed the [Google Style Guide](http://google.github.io/styleguide/javascriptguide.xml), however it hasn't been updated for ES2015, so we forked the [Airbnb Style Guide](https://github.com/airbnb/javascript) and ported a few rules from the Google Style Guide we liked, and added a few more that we found were sensible in our case.
 
-Terms parenthesised after the rule number is the matching rule name in [ESLint](eslint.org/docs/rules/).
+Terms parenthesised after the rule number is the matching rule name in [ESLint](http://eslint.org/docs/rules/).
 
 Our code currently isn't 100% compliant with this style guide, however we are working our way towards it.
 


### PR DESCRIPTION
I noticed the link to ESLint in the JavaScript coding guidelines README was broken. Since GitHub [now supports relative links](http://stackoverflow.com/questions/7653483/github-relative-link-in-markdown-file), a prefix needs to be prepended to a URL, or else it will try linking to the URL from within your repo. 

Currently, the link leads to `https://github.com/lyst/MakingLyst/blob/master/javascript/coding-standards/eslint.org/docs/rules`. I've added an `http://` prefix, so now it leads to the right place.
